### PR TITLE
Mark Durak Deck as "easy spectrum" for Spectrum Framework

### DIFF
--- a/modules/content/decks/durak_deck.lua
+++ b/modules/content/decks/durak_deck.lua
@@ -11,6 +11,7 @@ SMODS.Back {
         },
     },
     apply = function(self, back)
+        G.GAME.starting_params.easy_spectra = true
         G.E_MANAGER:add_event(Event({
             func = function()
                 local cards_to_remove = {}


### PR DESCRIPTION
Since that deck can score spectrums relatively easy and it dodges Spectrum Framework's auto detection, I think it's fair to set that flag.

Checked that it works in game.