### PR TITLE
Hex fixes

### DIFF
--- a/lovely/hexes.toml
+++ b/lovely/hexes.toml
@@ -1,0 +1,17 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+match_indent = true
+pattern = 'new_card:set_base(other.config.card)'
+position = "after"
+payload = '''
+for k, _ in pairs(new_card and new_card.ability or {}) do
+    if GB.HEX_LOOKUP_KEYS[k] then
+        new_card.ability[k] = nil
+    end
+end'''

--- a/modules/content/hexes/!hexes.lua
+++ b/modules/content/hexes/!hexes.lua
@@ -45,6 +45,12 @@ GB.HEX_KEYS = {
         "inflexible",
         "slothful",
     }
+    
+GB.HEX_LOOKUP_KEYS = { }
+for _, v in ipairs(GB.HEX_KEYS) do
+    GB.HEX_LOOKUP_KEYS['gb_' .. v .. '_hex'] = true
+end
+
 
 local function hexes_ui()
     local hexes = {}

--- a/modules/content/hexes/slothful.lua
+++ b/modules/content/hexes/slothful.lua
@@ -17,7 +17,7 @@ GB.Hex {
 		return { vars = { new_numerator, new_denominator } }
     end,
     calculate = function(self, card, context)
-        if context.modify_scoring_hand and context.other_card == card then
+        if context.modify_scoring_hand and context.other_card == card and context.in_scoring then
             if SMODS.pseudorandom_probability(card, 'slothful', 1, card.ability[self.key].extra.odds) then
                 return {
                     remove_from_hand = true


### PR DESCRIPTION
Slothful now only runs a probability check when a hand is played, meaning it doesn't trigger Jokers that are affected by the outcome of probability rolls.
Hexes are now removed when the card it's on is on the left side of a death tarot usage